### PR TITLE
Add a new command for releasing until it can be integrated into github actions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,15 @@ image/local: #help: builds and tags a docker image destined for a local registry
 		--build-arg COMMIT_DATE="$(shell git log -1 --format=%ci)"
 	docker push localhost:5000/havulv/reflector:latest
 
+image/release:
+	@docker build . -t gcr.io/havulv/reflector:$(shell git describe --tags --always) \
+		--build-arg COMMIT_HASH="$(shell git rev-parse --short HEAD)" \
+		--build-arg SEMVER="$(shell git describe --tags --always --dirty)" \
+		--build-arg COMMIT_DATE="$(shell git log -1 --format=%ci)"
+	docker push gcr.io/havulv/reflector:$(shell git describe --tags --always)
+
+
+
 .PHONY: docs
 docs:
 	mkdocs serve -f .config/mkdocs.yaml


### PR DESCRIPTION
Just a small helper for when there is a release needed. When the github action for releasing a new version is integrated then this can be deprecated or used as a backup.